### PR TITLE
Fixed the directory name for the plugin hierarchy in the API tutorial.

### DIFF
--- a/hack/api.md
+++ b/hack/api.md
@@ -87,7 +87,7 @@ the following hierarchy:
         └── src
             └── main
                 └── java
-                    └── org.apache.cloudstack
+                    └── org/apache/cloudstack
                         └── api
                             └── command  # for API command classes
                             └── response # for API response classes


### PR DESCRIPTION
Modified the directory name of the folder that contains the plugin API and Service layers from `org.apache.cloudstack` to `org/apache/cloudstack`. Naming the dir with the earlier option results in compilation errors since Maven is unable to find the plugin packages. 